### PR TITLE
NO_JIRA: customisable text style in text input field

### DIFF
--- a/app/src/main/java/com/schibsted/nmp/warpapp/ui/TextFieldScreen.kt
+++ b/app/src/main/java/com/schibsted/nmp/warpapp/ui/TextFieldScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.unit.dp
 import com.schibsted.nmp.warp.components.WarpText
 import com.schibsted.nmp.warp.components.WarpTextField
 import com.schibsted.nmp.warp.components.WarpTextStyle
+import com.schibsted.nmp.warp.theme.WarpTheme.typography
 
 @Composable
 fun TextFieldScreen(onUp: () -> Unit) {
@@ -221,6 +222,26 @@ fun TextFieldScreen(onUp: () -> Unit) {
                     helpText = "Helping text",
                     leadingIcon = leadingIcon.takeIf { showLeadingIcon },
                     trailingIcon = trailingIcon.takeIf { showTrailingIcon },
+                )
+            }
+            Column(
+                modifier = Modifier.padding(vertical = 8.dp)
+            ) {
+                WarpText(
+                    "Text style",
+                    style = WarpTextStyle.Body,
+                    modifier = Modifier.padding(vertical = 16.dp)
+                )
+                WarpTextField(
+                    value = text,
+                    onValueChange = { text = it },
+                    modifier = Modifier.fillMaxWidth(),
+                    isError = showError,
+                    label = "With title1 as text style",
+                    helpText = "Helping text",
+                    leadingIcon = leadingIcon.takeIf { showLeadingIcon },
+                    trailingIcon = trailingIcon.takeIf { showTrailingIcon },
+                    textStyle = typography.title1,
                 )
             }
         }

--- a/app/src/main/java/com/schibsted/nmp/warpapp/ui/TextFieldScreen.kt
+++ b/app/src/main/java/com/schibsted/nmp/warpapp/ui/TextFieldScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.unit.dp
 import com.schibsted.nmp.warp.components.WarpText
 import com.schibsted.nmp.warp.components.WarpTextField
 import com.schibsted.nmp.warp.components.WarpTextStyle
-import com.schibsted.nmp.warp.theme.WarpTheme.typography
 
 @Composable
 fun TextFieldScreen(onUp: () -> Unit) {
@@ -241,7 +240,7 @@ fun TextFieldScreen(onUp: () -> Unit) {
                     helpText = "Helping text",
                     leadingIcon = leadingIcon.takeIf { showLeadingIcon },
                     trailingIcon = trailingIcon.takeIf { showTrailingIcon },
-                    textStyle = typography.title1,
+                    textStyle = WarpTextStyle.Title1,
                 )
             }
         }

--- a/warp/src/main/java/com/schibsted/nmp/warp/components/WarpTextField.kt
+++ b/warp/src/main/java/com/schibsted/nmp/warp/components/WarpTextField.kt
@@ -79,7 +79,8 @@ fun WarpTextField(
     keyboardActions: KeyboardActions = KeyboardActions.Default,
     singleLine: Boolean = false,
     maxLines: Int = Int.MAX_VALUE,
-    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    textStyle: TextStyle = typography.body,
 ) {
     val textFieldColors = OutlinedTextFieldDefaults.colors(
         unfocusedTextColor = colors.text.default,
@@ -187,7 +188,7 @@ fun WarpTextField(
         val textColor = rememberUpdatedState(textColorValue).value
         //Help text color should remain the same if isError is true and the textfield is focused
         val helpTextColor = rememberUpdatedState(if (isError) colors.text.negative else if (!enabled) colors.text.disabled else colors.text.default).value
-        val mergedTextStyle = typography.body.merge(TextStyle(color = textColor))
+        val mergedTextStyle = textStyle.merge(TextStyle(color = textColor))
         val cursorColor = rememberUpdatedState(if (isError) colors.icon.negative else colors.icon.default).value
         val cursorHandleColor = rememberUpdatedState(if (isError) colors.icon.negative else colors.border.focus).value
 

--- a/warp/src/main/java/com/schibsted/nmp/warp/components/WarpTextField.kt
+++ b/warp/src/main/java/com/schibsted/nmp/warp/components/WarpTextField.kt
@@ -81,7 +81,7 @@ fun WarpTextField(
     singleLine: Boolean = false,
     maxLines: Int = Int.MAX_VALUE,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    textStyle: TextStyle = typography.body,
+    textStyle: WarpTextStyle = WarpTextStyle.Body,
 ) {
     val textFieldColors = OutlinedTextFieldDefaults.colors(
         unfocusedTextColor = colors.text.default,
@@ -189,7 +189,7 @@ fun WarpTextField(
         val textColor = rememberUpdatedState(textColorValue).value
         //Help text color should remain the same if isError is true and the textfield is focused
         val helpTextColor = rememberUpdatedState(if (isError) colors.text.negative else if (!enabled) colors.text.disabled else colors.text.default).value
-        val mergedTextStyle = textStyle.merge(TextStyle(color = textColor))
+        val mergedTextStyle = getTextStyle(style = textStyle).merge(TextStyle(color = textColor))
         val cursorColor = rememberUpdatedState(if (isError) colors.icon.negative else colors.icon.default).value
         val cursorHandleColor = rememberUpdatedState(if (isError) colors.icon.negative else colors.border.focus).value
 

--- a/warp/src/main/java/com/schibsted/nmp/warp/components/legacy/WarpTextFieldView.kt
+++ b/warp/src/main/java/com/schibsted/nmp/warp/components/legacy/WarpTextFieldView.kt
@@ -19,7 +19,9 @@ import androidx.compose.ui.res.painterResource
 import androidx.core.content.withStyledAttributes
 import com.schibsted.nmp.warp.R
 import com.schibsted.nmp.warp.components.WarpTextField
+import com.schibsted.nmp.warp.components.WarpTextStyle
 import com.schibsted.nmp.warp.components.ext.getTextFromIdOrString
+import com.schibsted.nmp.warp.components.getTextStyle
 import org.koin.java.KoinJavaComponent.inject
 
 
@@ -111,6 +113,29 @@ class WarpTextFieldView @JvmOverloads constructor(
             disposeComposition()
         }
 
+    var textStyle: WarpTextStyle = WarpTextStyle.Body
+        set(value) {
+            field = value
+            disposeComposition()
+        }
+
+    private var stylesList = listOf(
+        WarpTextStyle.Display,
+        WarpTextStyle.Title1,
+        WarpTextStyle.Title2,
+        WarpTextStyle.Title3,
+        WarpTextStyle.Title4,
+        WarpTextStyle.Title5,
+        WarpTextStyle.Title6,
+        WarpTextStyle.Preamble,
+        WarpTextStyle.Body,
+        WarpTextStyle.BodyStrong,
+        WarpTextStyle.Caption,
+        WarpTextStyle.CaptionStrong,
+        WarpTextStyle.Detail,
+        WarpTextStyle.DetailStrong
+    )
+
     init {
         context.withStyledAttributes(attrs, R.styleable.WarpTextField) {
             textFieldEnabled = getBoolean(R.styleable.WarpTextField_textFieldEnabled, true)
@@ -131,6 +156,8 @@ class WarpTextFieldView @JvmOverloads constructor(
             isError = getBoolean(R.styleable.WarpTextField_isError, false)
             singleLine = getBoolean(R.styleable.WarpTextField_singleLine, false)
             maxLines = getInt(R.styleable.WarpTextField_maxLines, Int.MAX_VALUE)
+            val styleInt = getInteger(R.styleable.WarpText_warpTextStyle, 8)
+            textStyle = stylesList[styleInt]
         }
     }
 
@@ -179,6 +206,7 @@ class WarpTextFieldView @JvmOverloads constructor(
                 isError = isError,
                 singleLine = singleLine,
                 maxLines = maxLines,
+                textStyle = getTextStyle(style = textStyle),
             )
         }
     }

--- a/warp/src/main/java/com/schibsted/nmp/warp/components/legacy/WarpTextFieldView.kt
+++ b/warp/src/main/java/com/schibsted/nmp/warp/components/legacy/WarpTextFieldView.kt
@@ -21,7 +21,6 @@ import com.schibsted.nmp.warp.R
 import com.schibsted.nmp.warp.components.WarpTextField
 import com.schibsted.nmp.warp.components.WarpTextStyle
 import com.schibsted.nmp.warp.components.ext.getTextFromIdOrString
-import com.schibsted.nmp.warp.components.getTextStyle
 import org.koin.java.KoinJavaComponent.inject
 
 
@@ -156,7 +155,7 @@ class WarpTextFieldView @JvmOverloads constructor(
             isError = getBoolean(R.styleable.WarpTextField_isError, false)
             singleLine = getBoolean(R.styleable.WarpTextField_singleLine, false)
             maxLines = getInt(R.styleable.WarpTextField_maxLines, Int.MAX_VALUE)
-            val styleInt = getInteger(R.styleable.WarpText_warpTextStyle, 8)
+            val styleInt = getInteger(R.styleable.WarpTextField_textStyle, 8)
             textStyle = stylesList[styleInt]
         }
     }
@@ -206,7 +205,7 @@ class WarpTextFieldView @JvmOverloads constructor(
                 isError = isError,
                 singleLine = singleLine,
                 maxLines = maxLines,
-                textStyle = getTextStyle(style = textStyle),
+                textStyle = textStyle,
             )
         }
     }

--- a/warp/src/main/res/values/attrs.xml
+++ b/warp/src/main/res/values/attrs.xml
@@ -57,6 +57,22 @@
         <attr name="isError" format="boolean" />
         <attr name="singleLine" format="boolean" />
         <attr name="maxLines" format="integer" />
+        <attr name="textStyle" format="enum">
+            <enum name="display" value="0" />
+            <enum name="title1" value="1" />
+            <enum name="title2" value="2" />
+            <enum name="title3" value="3" />
+            <enum name="title4" value="4" />
+            <enum name="title5" value="5" />
+            <enum name="title6" value="6" />
+            <enum name="preamble" value="7" />
+            <enum name="body" value="8" />
+            <enum name="bodyStrong" value="9" />
+            <enum name="caption" value="10" />
+            <enum name="captionStrong" value="11" />
+            <enum name="detail" value="12" />
+            <enum name="detailStrong" value="13" />
+        </attr>
     </declare-styleable>
 
     <declare-styleable name="WarpBadge">


### PR DESCRIPTION
In TJT and I saw in some other places sometimes we use `title1` or `title2` text style instead of `body` that now is default and there is no option to have other text style. So I added another parameter `textStyle` to be able to use some other text style in input fields.