### PR TITLE
Adjust padding for small warp button

### DIFF
--- a/warp/src/main/java/com/schibsted/nmp/warp/components/WarpButton.kt
+++ b/warp/src/main/java/com/schibsted/nmp/warp/components/WarpButton.kt
@@ -189,8 +189,8 @@ fun WarpButton(
             {}
         } else onClick
 
-        val paddingVertical = if (small) dimensions.space025 else dimensions.space2
-        val paddingHorizontal = if (small) dimensions.space025 else dimensions.space2
+        val paddingVertical = if (small) 0.dp else dimensions.space2
+        val paddingHorizontal = if (small) dimensions.space15 else dimensions.space2
         val loadingModifier = if (loading) modifier.loadingAnimation() else modifier
         val smallModifier =
             if (small) modifier.height(dimensions.components.smallButtonHeight) else modifier


### PR DESCRIPTION
Padding was a bit too small when the text was longer

![Screenshot 2024-05-24 at 15 11 26](https://github.com/warp-ds/warp-android/assets/10745215/be2ac5d2-1d8c-4894-b0c7-a11c42ffebf9)
