### PR TITLE
Fixed bottom padding issue for Checkbox

### DIFF
--- a/warp/src/main/java/com/schibsted/nmp/warp/components/WarpCheckbox.kt
+++ b/warp/src/main/java/com/schibsted/nmp/warp/components/WarpCheckbox.kt
@@ -126,7 +126,7 @@ private fun WarpCheckboxView(
     ) {
 
         Box(
-            modifier = modifier
+            modifier = Modifier
                 .requiredSize(dimensions.components.checkbox.checkboxSize)
                 .background(
                     checkboxColor.value,


### PR DESCRIPTION
# Why?

I noticed that when I added bottom padding to the Checkbox component it was applied in a wrong way. We shouldn't use modifier that we pass to the Checkbox in Box.

# What?
 Small UI fix

# Show me

| Before      | After      |
|-------------|------------|
| ![Screenshot_20241017_124348](https://github.com/user-attachments/assets/6d638cbc-7aac-47d5-b498-fafc860eddea) |  ![Screenshot_20241017_124234](https://github.com/user-attachments/assets/c99098bc-d098-40c9-bb25-043e14a60574)|
