### PR TITLE
Add option to turn off dismiss on click outside

### DIFF
--- a/app/src/main/java/com/schibsted/nmp/warpapp/ui/CalloutScreen.kt
+++ b/app/src/main/java/com/schibsted/nmp/warpapp/ui/CalloutScreen.kt
@@ -124,6 +124,7 @@ fun CalloutScreenContent() {
                 edge = Edge.Bottom,
                 size = CalloutSize.Small,
                 closable = true,
+                dismissPopoverOnClickOutside = false,
                 onDismiss = { bottomCenterState.isVisible = false },
             ) {
                 WarpButton(

--- a/warp/src/main/java/com/schibsted/nmp/warp/components/WarpCallout.kt
+++ b/warp/src/main/java/com/schibsted/nmp/warp/components/WarpCallout.kt
@@ -52,6 +52,7 @@ fun WarpCallout(
     verticalOffset: Dp = 0.dp,
     edge: Edge = Edge.Top,
     closable: Boolean = false,
+    dismissPopoverOnClickOutside: Boolean = true,
     onDismiss: () -> Unit,
     anchorView: @Composable (() -> Unit)? = null,
 ) {
@@ -80,7 +81,9 @@ fun WarpCallout(
                     Popup(
                         popupPositionProvider = popupPositionProvider,
                         onDismissRequest = onDismiss,
-                        properties = PopupProperties()
+                        properties = PopupProperties(
+                            dismissOnClickOutside = dismissPopoverOnClickOutside
+                        )
                     ) {
                         CalloutView(
                             shadowModifier,


### PR DESCRIPTION
# Why?

When using `CalloutType.Popover` the default `PopupProperties` class is used which has `dismissOnClickOutside` set to true.

When using the callout as a closable tooltip, as soon as the user interacts with the screen the tool tip is dismissed. 

# What?

Provide a boolean named `dismissPopoverOnClickOutside` to turn this off if necessary.

- [x] Jetpack compose
- [ ] XML support
- [ ] Snapshot testing

# Show me

There was a concern that the pop-up would block the underlying view, this doesn't seem to be the case. Basic functionality test in video.

[test.webm](https://github.com/user-attachments/assets/0bed60c9-7544-4320-9979-c525105ab14e)

