### PR TITLE
Fix WarpButton text align with multiple lines text

### DIFF
--- a/app/src/main/java/com/schibsted/nmp/warpapp/ui/ButtonScreen.kt
+++ b/app/src/main/java/com/schibsted/nmp/warpapp/ui/ButtonScreen.kt
@@ -211,6 +211,29 @@ private fun ButtonScreenContent() {
                 text = "Click to focus",
                 )
         }
+        WarpText(
+            text = "With multiple lines",
+            modifier = Modifier.padding(
+                top = dimensions.space2,
+                bottom = dimensions.space05,
+                start = dimensions.space2,
+                end = dimensions.space2
+            )
+        )
+        Row(
+            horizontalArrangement = Arrangement.SpaceBetween, modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = dimensions.space2)
+        ) {
+            val focus = remember { FocusRequester() }
+
+            WarpButton(
+                modifier = Modifier.focusRequester(focus),
+                onClick = { focus.requestFocus() },
+                text = "Explore All Features and Compare Plans Before You Choose",
+                maxLines = 2
+            )
+        }
     }
 }
 

--- a/warp/src/main/java/com/schibsted/nmp/warp/components/WarpButton.kt
+++ b/warp/src/main/java/com/schibsted/nmp/warp/components/WarpButton.kt
@@ -13,9 +13,11 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.ripple.RippleAlpha
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -43,6 +45,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -105,6 +108,7 @@ fun WarpButton(
             overflow = TextOverflow.Ellipsis,
             maxLines = maxLines,
             style = textStyle,
+            textAlign = TextAlign.Center
         )
         trailingIcon?.let {
             it()


### PR DESCRIPTION
# Why?

WarpButton text wasn't centered when it contained multiple lines.

# What?

Add text align to WarpButton text component

# Show me

| Before      | After      |
|-------------|------------|
| ![Screenshot_20250612_112212](https://github.com/user-attachments/assets/95548c63-f584-455b-b819-8b87b1bb83ca) | ![Screenshot_20250612_112316](https://github.com/user-attachments/assets/b3116fc5-b9d4-4200-9b7b-63ec392edb37) |

