### PR TITLE
Add empty/blank string check

### DIFF
--- a/warp/src/main/java/com/schibsted/nmp/warp/theme/WarpIcons.kt
+++ b/warp/src/main/java/com/schibsted/nmp/warp/theme/WarpIcons.kt
@@ -43,7 +43,7 @@ object WarpIconResources {
     @SuppressLint("DiscouragedApi")
     @Composable
     fun getResourceIdByName(resourceName: String): Int {
-        if(resourceName.isBlank() || resourceName.isEmpty()) return 0
+        if(resourceName.isBlank()) return 0
         val context = LocalContext.current
         val resourceNameWithAppendix = if(!resourceName.contains("warp_")) "warp_$resourceName" else resourceName
         return context.resources.getIdentifier(resourceNameWithAppendix, "drawable", context.packageName)


### PR DESCRIPTION
# Why?

If a blank string is passed, returns a strange error, should return null
# What?

Blank and empty string check in all methods using a resource string to find an icon
