### PR TITLE
Add optional semantic role and state to WarpPill

### DIFF
--- a/warp/src/main/java/com/schibsted/nmp/warp/components/WarpPill.kt
+++ b/warp/src/main/java/com/schibsted/nmp/warp/components/WarpPill.kt
@@ -3,10 +3,12 @@ package com.schibsted.nmp.warp.components
 import androidx.compose.material3.InputChip
 import androidx.compose.material3.InputChipDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.tooling.preview.Preview
 import com.schibsted.nmp.warp.theme.WarpDimensions.adaptDpToFontScale
 import com.schibsted.nmp.warp.theme.WarpIconResource
@@ -20,7 +22,6 @@ import com.schibsted.nmp.warp.theme.WarpTheme.shapes
  * Supports two styles: filter and suggestion.
  * For more info, look [here](https://warp-ds.github.io/tech-docs/components/pill/)
  *
- *
  * @param modifier The modifier to be applied to the pill. Defaults to [Modifier].
  * @param text The text to be displayed in the pill.
  * @param onClick The callback to be invoked when the pill is clicked.
@@ -28,6 +29,8 @@ import com.schibsted.nmp.warp.theme.WarpTheme.shapes
  * @param style The style of the pill. Defaults to [WarpPillStyle.Filter].
  * @param closable Whether the pill is closable. When true, the pill will display a dismiss icon. Defaults to false.
  * @param icon The icon to be displayed in the pill. If provided, the dismiss icon will not be displayed.
+ * @param semanticRole The semantic role of the pill. Defaults to [Role.Checkbox].
+ * @param semanticStateDescription The semantic state description of the pill. Defaults to "Selected" if the pill is selected, "Not selected" otherwise.
  */
 @Composable
 fun WarpPill(
@@ -37,7 +40,9 @@ fun WarpPill(
     selected: Boolean = false,
     style: WarpPillStyle = WarpPillStyle.Filter,
     closable: Boolean = false,
-    icon: WarpIconResource? = null
+    icon: WarpIconResource? = null,
+    semanticRole: Role? = null,
+    semanticStateDescription: String? = null
 ) {
     val warpPillColors: WarpPillStyleColors = when (style) {
         WarpPillStyle.Filter -> pillStyleFilter()
@@ -70,7 +75,12 @@ fun WarpPill(
         shape = shapes.ellipse,
         colors = pillColors,
         border = null,
-        modifier = modifier,
+        modifier = Modifier
+            .semantics {
+                role = semanticRole ?: Role.Checkbox;
+                stateDescription = semanticStateDescription ?: if (selected) "Selected" else "Not selected"
+            }
+            .then(modifier),
         trailingIcon = if (closable) {
             {
                 WarpIcon(


### PR DESCRIPTION
# Why?

Pill component had Role.Checkbox by default, even though not always used as one

# What?

Role and state have been added to WarpPill enabling the developer to more accurately describe the component with a screenreader


