### PR TITLE
Add scrolledContainerColor to WarpTopAppBar

### DIFF
--- a/warp/src/main/java/com/schibsted/nmp/warp/components/WarpTopAppBar.kt
+++ b/warp/src/main/java/com/schibsted/nmp/warp/components/WarpTopAppBar.kt
@@ -40,6 +40,7 @@ fun WarpTopAppBar(
         titleContentColor = colors.text.default,
         navigationIconContentColor = colors.icon.default,
         actionIconContentColor = colors.icon.default,
+        scrolledContainerColor = colors.background.default
     )
     if (centered) {
         CenterAlignedTopAppBar(


### PR DESCRIPTION
# Why?

scrolledContainerColor was not set so the system colors were used

# What?

scrolledContainerColor is now set to background.default color
