### PR TITLE
Fix focus alpha for finn theme

### DIFF
--- a/warp-finn/src/main/java/com/schibsted/nmp/warp/brands/finn/FinnWarpTheme.kt
+++ b/warp-finn/src/main/java/com/schibsted/nmp/warp/brands/finn/FinnWarpTheme.kt
@@ -21,7 +21,7 @@ fun FinnWarpTheme(
     val finnResources = WarpResources
     val finnRippleConfig = RippleConfiguration(
         color = finnColors.background.active,
-        rippleAlpha = RippleAlpha(0f, 0f, 0f, 0.5f)
+        rippleAlpha = RippleAlpha(0f, 0.5f, 0f, 0.5f)
     )
 
     WarpTheme(


### PR DESCRIPTION
# Why?

With the alpha set to zero keyboard navigation does not display what item is selected for components that are not explicitly warp components that override the focused state like warpbutton. 

# What?

Increased the focus alpha to be 0.5 to be in line with the other themes.

- [X] Jetpack compose
- [ ] XML support
- [ ] Snapshot testing

# Show me

| Before      | After      |
|-------------|------------|
| <img width="1080" height="2400" alt="Screenshot_20260415_155818" src="https://github.com/user-attachments/assets/dd2836b6-efd2-483e-b19d-41392f31a027" /> | <img width="1080" height="2400" alt="Screenshot_20260415_155741" src="https://github.com/user-attachments/assets/f73f7407-3ea4-452c-bce9-470bf4a7ee59" /> |


