### PR TITLE
Add Firebase App Distribution workflow for demo app

### DIFF
--- a/.github/workflows/distribute-demo-app.yml
+++ b/.github/workflows/distribute-demo-app.yml
@@ -1,0 +1,46 @@
+name: Distribute Warp Demo App
+
+on:
+  # Manual trigger from GitHub Actions UI
+  workflow_dispatch:
+    inputs:
+      release_note:
+        description: 'Release notes'
+        required: false
+        default: 'Warp demo app build'
+        type: string
+
+  # Optional: Automated weekly build every Wednesday at 6 PM UTC
+  # Remove this section if you don't want automated builds
+  schedule:
+    - cron: "0 18 * * 3"
+
+jobs:
+  distribute:
+    name: Build and distribute demo app
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Build debug APK
+        run: ./gradlew app:assembleDebug
+
+      - name: Upload to Firebase App Distribution
+        uses: wzieba/Firebase-Distribution-Github-Action@v1
+        with:
+          appId: ${{ secrets.FIREBASE_APP_ID }}
+          serviceCredentialsFileContent: ${{ secrets.FIREBASE_CREDENTIALS }}
+          groups: warp-android-testers
+          releaseNotes: ${{ inputs.release_note || 'Warp demo app - automated build' }}
+          file: app/build/outputs/apk/debug/app-debug.apk


### PR DESCRIPTION
(cherry picked from commit 1289d5ea23ba9005d80589aaf3ae0046bb8df7ac)

# Why?

Workflow was not available when added to the main branch. We need it in develop as well.