### PR TITLE
Fix Artifactory plugin setup

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,10 +39,7 @@ buildscript {
         }
     }
     dependencies {
-        if (enableArtifactory) {
-            classpath("com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4")
-            classpath("org.jfrog.buildinfo:build-info-extractor-gradle:5.1.6")
-        }
+        classpath("org.jfrog.buildinfo:build-info-extractor-gradle:5.1.6")
     }
 }
 

--- a/warp-blocket/build.gradle.kts
+++ b/warp-blocket/build.gradle.kts
@@ -10,7 +10,9 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("maven-publish")
 }
-apply(plugin = "com.jfrog.artifactory")
+if (project.hasProperty("PUBLISH_TO_ARTIFACTORY")) {
+    apply(plugin = "com.jfrog.artifactory")
+}
 
 android {
     namespace = ConfigData.namespaceBlocket

--- a/warp-dba/build.gradle.kts
+++ b/warp-dba/build.gradle.kts
@@ -4,7 +4,9 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("maven-publish")
 }
-apply(plugin = "com.jfrog.artifactory")
+if (project.hasProperty("PUBLISH_TO_ARTIFACTORY")) {
+    apply(plugin = "com.jfrog.artifactory")
+}
 
 android {
     namespace = ConfigData.namespaceDba

--- a/warp-finn/build.gradle.kts
+++ b/warp-finn/build.gradle.kts
@@ -3,7 +3,9 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("maven-publish")
 }
-apply(plugin = "com.jfrog.artifactory")
+if (project.hasProperty("PUBLISH_TO_ARTIFACTORY")) {
+    apply(plugin = "com.jfrog.artifactory")
+}
 
 android {
     namespace = ConfigData.namespaceFinn

--- a/warp-neutral/build.gradle.kts
+++ b/warp-neutral/build.gradle.kts
@@ -10,7 +10,9 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("maven-publish")
 }
-apply(plugin = "com.jfrog.artifactory")
+if (project.hasProperty("PUBLISH_TO_ARTIFACTORY")) {
+    apply(plugin = "com.jfrog.artifactory")
+}
 
 android {
     namespace = ConfigData.namespaceNeutral

--- a/warp-tori/build.gradle.kts
+++ b/warp-tori/build.gradle.kts
@@ -3,7 +3,9 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("maven-publish")
 }
-apply(plugin = "com.jfrog.artifactory")
+if (project.hasProperty("PUBLISH_TO_ARTIFACTORY")) {
+    apply(plugin = "com.jfrog.artifactory")
+}
 
 android {
     namespace = ConfigData.namespaceTori

--- a/warp-vend/build.gradle.kts
+++ b/warp-vend/build.gradle.kts
@@ -10,7 +10,9 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("maven-publish")
 }
-apply(plugin = "com.jfrog.artifactory")
+if (project.hasProperty("PUBLISH_TO_ARTIFACTORY")) {
+    apply(plugin = "com.jfrog.artifactory")
+}
 
 android {
     namespace = ConfigData.namespaceVend

--- a/warp/build.gradle.kts
+++ b/warp/build.gradle.kts
@@ -3,7 +3,9 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("maven-publish")
 }
-apply(plugin = "com.jfrog.artifactory")
+if (project.hasProperty("PUBLISH_TO_ARTIFACTORY")) {
+    apply(plugin = "com.jfrog.artifactory")
+}
 
 android {
     namespace = ConfigData.namespaceWarp


### PR DESCRIPTION
# Why?

When introducing `enableArtifactory` we guarded a bit too much. We still need to load the dependency to be able to recognize `ArtifactoryPluginConvention` etc. compile time.
 
# What?

Reduced the impact of the `enableArtifactory` guard to the required level.
Removed `gradle-bintray-plugin` which is apparently not needed.