### PR TITLE
Warp-1344 Create snackbar component

### DIFF
--- a/app/src/main/java/com/schibsted/nmp/warpapp/ui/MainScreen.kt
+++ b/app/src/main/java/com/schibsted/nmp/warpapp/ui/MainScreen.kt
@@ -177,6 +177,11 @@ fun MainScreen() {
                     navController.navigateUp()
                 }
             }
+            composable("snackbar") {
+                SnackbarScreen {
+                    navController.navigateUp()
+                }
+            }
             composable("datePicker") {
                 DatePickerScreen {
                     navController.navigateUp()
@@ -280,6 +285,7 @@ fun ComponentListScreen(onNavigate: (String) -> Unit) {
                         "rangeSlider" to "WarpRangeSlider",
                         "select" to "WarpSelect",
                         "slider" to "WarpSlider",
+                        "snackbar" to "WarpSnackbar",
                         "spinner" to "WarpSpinner",
                         "state" to "WarpState",
                         "stepIndicator" to "WarpStepIndicator",

--- a/app/src/main/java/com/schibsted/nmp/warpapp/ui/SnackbarScreen.kt
+++ b/app/src/main/java/com/schibsted/nmp/warpapp/ui/SnackbarScreen.kt
@@ -1,0 +1,113 @@
+package com.schibsted.nmp.warpapp.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.schibsted.nmp.warp.components.WarpButton
+import com.schibsted.nmp.warp.components.WarpScaffold
+import com.schibsted.nmp.warp.components.WarpSnackbar
+import com.schibsted.nmp.warp.theme.WarpTheme.dimensions
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+@Composable
+fun SnackbarScreen(onUp: () -> Unit) {
+    DetailsScaffold(
+        title = "WarpSnackbar",
+        onUp = onUp
+    ) {
+        SnackbarScreenContent()
+    }
+}
+
+@Composable
+fun SnackbarScreenContent() {
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+    var actionOnNewLine by remember { mutableStateOf(false) }
+
+    WarpScaffold(
+        snackbarHost = {
+            SnackbarHost(
+                hostState = snackbarHostState
+            ) { data ->
+                WarpSnackbar(
+                    snackbarData = data,
+                    actionOnNewLine = actionOnNewLine,
+                )
+            }
+        },
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(dimensions.space1)
+                .fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Top
+        ) {
+            WarpButton(modifier = Modifier.padding(bottom = dimensions.space2),
+                text = "Show snackbar",
+                onClick = {
+                    actionOnNewLine = false
+                    showSnackbar(
+                        snackbarHostState = snackbarHostState,
+                        scope = scope,
+                        message = "Snackbar message"
+                    )
+                })
+            WarpButton(modifier = Modifier.padding(bottom = dimensions.space2),
+                text = "Show snackbar with action",
+                onClick = {
+                    actionOnNewLine = false
+                    showSnackbar(
+                        snackbarHostState = snackbarHostState,
+                        scope = scope,
+                        message = "Snackbar message",
+                        actionLabel = "Action"
+                    )
+                })
+            WarpButton(modifier = Modifier.padding(bottom = dimensions.space2),
+                text = "Show snackbar with longer action",
+                onClick = {
+                    actionOnNewLine = true
+                    showSnackbar(
+                        snackbarHostState = snackbarHostState,
+                        scope = scope,
+                        message = "Snackbar message",
+                        actionLabel = "Longer Action",
+
+                    )
+                })
+        }
+    }
+}
+
+fun showSnackbar(
+    snackbarHostState: SnackbarHostState,
+    scope: CoroutineScope,
+    message: String,
+    actionLabel: String? = null,
+    withDismissAction: Boolean = true,
+    duration: SnackbarDuration = SnackbarDuration.Short,
+) {
+    scope.launch {
+        snackbarHostState.showSnackbar(
+            message = message,
+            withDismissAction = withDismissAction,
+            actionLabel = actionLabel,
+            duration = duration
+        )
+    }
+}

--- a/warp/src/main/java/com/schibsted/nmp/warp/components/WarpSnackbar.kt
+++ b/warp/src/main/java/com/schibsted/nmp/warp/components/WarpSnackbar.kt
@@ -1,0 +1,50 @@
+package com.schibsted.nmp.warp.components
+
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarData
+import androidx.compose.material3.SnackbarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import com.schibsted.nmp.warp.theme.WarpTheme
+
+/**
+ * A snackbar in the Warp design system.
+ * Snackbars provide brief messages about app processes at the bottom of the screen.
+ * For more info, look [here](https://warp-ds.github.io/tech-docs/components/snackbar/)
+ *
+ * @param snackbarData Data about the snackbar, including text and action label.
+ * @param modifier Modifier for the snackbar.
+ * @param actionOnNewLine Whether the action should be placed on a new line.
+ * @param shape The shape of the snackbar.
+ * @param containerColor The background color of the snackbar.
+ * @param contentColor The color for the text content.
+ * @param actionColor The text color for the action button.
+ * @param actionContentColor The content color for the action.
+ * @param dismissActionContentColor The color for the dismiss icon.
+ */
+@Composable
+fun WarpSnackbar(
+    snackbarData: SnackbarData,
+    modifier: Modifier = Modifier,
+    actionOnNewLine: Boolean = false,
+    shape: Shape = SnackbarDefaults.shape,
+    containerColor: Color = WarpTheme.colors.background.default,
+    contentColor: Color = WarpTheme.colors.text.default,
+    actionColor: Color = WarpTheme.colors.text.default,
+    actionContentColor: Color = SnackbarDefaults.actionContentColor,
+    dismissActionContentColor: Color = WarpTheme.colors.icon.default,
+) {
+    Snackbar(
+        snackbarData = snackbarData,
+        modifier = modifier,
+        actionOnNewLine = actionOnNewLine,
+        shape = shape,
+        containerColor = containerColor,
+        contentColor = contentColor,
+        actionColor = actionColor,
+        actionContentColor = actionContentColor,
+        dismissActionContentColor = dismissActionContentColor,
+    )
+}


### PR DESCRIPTION
# Why?

Native Android Snackbar to use with WarpScaffold `(snackbarHost = {}`)

# What?

- `WarpSnackbar` has the same params as Android `Snackbar`
- bkgnd color: `WarpTheme.colors.background.default`
- context text color and action button color: `WarpTheme.colors.text.default`
- close icon color: `WarpTheme.colors.icon.default`

The WarpSnackbar default layout will get the font styling for content and button from Material 3 theme's `bodyMedium` and `labelLarge`

- [x] Jetpack compose
- [ ] XML support
- [ ] Snapshot testing

# Show me

<img width="1080" height="1920" alt="Screenshot_20260511_104658" src="https://github.com/user-attachments/assets/6b7f01f5-d9f8-42e1-ac5e-b433e9d5ba2b" />
