### PR TITLE
Proposed fix for callout

### DIFF
--- a/app/src/main/java/com/schibsted/nmp/warpapp/ui/CalloutScreen.kt
+++ b/app/src/main/java/com/schibsted/nmp/warpapp/ui/CalloutScreen.kt
@@ -111,7 +111,6 @@ fun CalloutScreenContent() {
                 type = CalloutType.Popover,
                 size = CalloutSize.Small,
                 closable = true,
-                paddingOffset = dimensions.space2,
                 onDismiss = { centerStartState.isVisible = false },
             ) {
                 WarpButton (
@@ -143,7 +142,6 @@ fun CalloutScreenContent() {
                 edge = Edge.Top,
                 size = CalloutSize.Small,
                 closable = true,
-                paddingOffset = dimensions.space2,
                 onDismiss = { centerEndState.isVisible = false },
             ) {
                 WarpButton(

--- a/warp/src/main/java/com/schibsted/nmp/warp/components/WarpCallout.kt
+++ b/warp/src/main/java/com/schibsted/nmp/warp/components/WarpCallout.kt
@@ -82,6 +82,7 @@ fun WarpCallout(
         edge = edge
     )
 
+    val density = LocalDensity.current
     var anchorWidth: Dp? = null
     var anchorPosition: Offset? = null
 
@@ -90,7 +91,7 @@ fun WarpCallout(
             Box(
                 modifier = Modifier
                     .onGloballyPositioned { coordinates ->
-                        anchorWidth = coordinates.size.width.dp
+                        anchorWidth = with(density) { coordinates.size.width.toDp() }
                         anchorPosition = coordinates.positionInWindow()
                     }
             ) {

--- a/warp/src/main/java/com/schibsted/nmp/warp/components/shapes/CalloutShape.kt
+++ b/warp/src/main/java/com/schibsted/nmp/warp/components/shapes/CalloutShape.kt
@@ -2,7 +2,6 @@ package com.schibsted.nmp.warp.components.shapes
 
 import androidx.compose.foundation.shape.GenericShape
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
@@ -38,8 +37,6 @@ fun calloutShape(
     val cornerRadius = with(density) {
         dimensions.components.callout.cornerRadius.toPx()
     }
-    var alignment = Alignment.CenterHorizontally
-
     val paddingOffset: Float = with(density) {
         padding?.toPx()
     } ?: 0f
@@ -49,25 +46,27 @@ fun calloutShape(
         CalloutSize.Default -> 3f
     }
 
-    if (anchorPosition != null && anchorWidth != null) {
-        val screenHeightPx = with(density) { configuration.screenHeightDp.dp.toPx() }
-        val anchorWidthPx = with(density) { anchorWidth.toPx() }
-        val anchorCenterX = anchorPosition.x + (anchorWidthPx / 2)
+    val screenWidthPx = with(density) { configuration.screenWidthDp.dp.toPx() }
+    val anchorWidthPx = anchorWidth?.let { with(density) { it.toPx() } }
+    val anchorCenterX = if (anchorPosition != null && anchorWidthPx != null) {
+        anchorPosition.x + (anchorWidthPx / 2)
+    } else null
 
-        val leftThreshold = screenHeightPx / 3
-        val rightThreshold = screenHeightPx * 2 / 3
-        val centerThreshold = screenHeightPx / 2
-
-        alignment = when {
-            anchorCenterX < leftThreshold && anchorCenterX < centerThreshold -> Alignment.Start
-            anchorCenterX < rightThreshold && anchorCenterX > centerThreshold -> Alignment.End
-            else -> Alignment.CenterHorizontally
-        }
+    fun arrowOffset(popupWidth: Float): Float {
+        if (anchorCenterX == null) return 0f
+        val idealPopupLeft = anchorCenterX - popupWidth / 2
+        val minPopupLeft = paddingOffset
+        val maxPopupLeft = screenWidthPx - popupWidth - paddingOffset
+        val actualPopupLeft = idealPopupLeft.coerceIn(minPopupLeft, maxPopupLeft)
+        val actualPopupCenterX = actualPopupLeft + popupWidth / 2
+        val offset = anchorCenterX - actualPopupCenterX
+        val maxOffset = popupWidth / 2 - tipWidth / 2 - cornerRadius
+        return offset.coerceIn(-maxOffset, maxOffset)
     }
 
     return when (arrowEdge) {
         Edge.Trailing -> {
-            GenericShape { size: Size, layoutDirection: LayoutDirection ->
+            GenericShape { size: Size, _: LayoutDirection ->
                 addPath(Path().apply {
                     moveTo(cornerRadius, 0f)
                     lineTo(size.width - tipHeight - cornerRadius, 0f)
@@ -160,16 +159,8 @@ fun calloutShape(
         }
 
         Edge.Top -> {
-            GenericShape { size: Size, layoutDirection: LayoutDirection ->
-                val shapeWidth = size.width
-                var diff = 0f
-                if (anchorWidth != null && shapeWidth > anchorWidth.value) {
-                    diff = when (alignment) {
-                        Alignment.Start -> -(shapeWidth - anchorWidth.value) / 2 + paddingOffset
-                        Alignment.End -> (shapeWidth - anchorWidth.value) / 2 - paddingOffset
-                        else -> 0f
-                    }
-                }
+            GenericShape { size: Size, _: LayoutDirection ->
+                val diff = arrowOffset(size.width)
                 addPath(Path().apply {
                     moveTo(cornerRadius, tipHeight)
                     lineTo((size.width / 2 - tipWidth / 2) + diff, tipHeight)
@@ -250,16 +241,8 @@ fun calloutShape(
         }
 
         Edge.Bottom -> {
-            GenericShape { size: Size, layoutDirection: LayoutDirection ->
-                val shapeWidth = size.width
-                var diff = 0f
-                if (anchorWidth != null && shapeWidth > anchorWidth.value) {
-                    diff = when (alignment) {
-                        Alignment.Start -> -(shapeWidth - anchorWidth.value) / 2 + paddingOffset
-                        Alignment.End -> (shapeWidth - anchorWidth.value) / 2 - paddingOffset
-                        else -> 0f
-                    }
-                }
+            GenericShape { size: Size, _: LayoutDirection ->
+                val diff = arrowOffset(size.width)
                 addPath(Path().apply {
                     moveTo(cornerRadius, 0f)
                     lineTo(size.width - cornerRadius, 0f)
@@ -329,7 +312,7 @@ fun calloutShape(
         }
 
         Edge.Leading -> {
-            GenericShape { size: Size, layoutDirection: LayoutDirection ->
+            GenericShape { size: Size, _: LayoutDirection ->
                 addPath(Path().apply {
                     moveTo(tipHeight + cornerRadius, 0f)
                     lineTo(size.width - cornerRadius, 0f)


### PR DESCRIPTION
# Why?

The callout arrow was not pointing at the center of its anchor view when the popup was constrained to screen bounds. Two root causes:

1. **Wrong anchor width conversion** -- `coordinates.size.width.dp` treats raw pixel values as dp, inflating the width by the device density factor (e.g. ~2.75x on xxhdpi). This caused the arrow to aim at the wrong horizontal position.

2. **Coarse alignment bucketing** -- The old code divided the screen into thirds and snapped the arrow to Start/Center/End. This produced visible misalignment for anchors that weren't near those bucket boundaries. It also used `screenHeightDp` for horizontal thresholds, which was an additional bug.

# What?

**`WarpCallout.kt`** -- Fixed anchor width measurement from `coordinates.size.width.dp` to `with(density) { coordinates.size.width.toDp() }` for correct pixel-to-dp conversion.

**`CalloutShape.kt`** -- Replaced the Start/Center/End bucketing with a precise calculation that:
- Computes where Compose would position the popup (centered on anchor, clamped to screen bounds with padding margin)
- Offsets the arrow tip by the difference between the popup center and the anchor center
- Clamps the offset so the arrow never draws outside the popup's rounded-corner body

Extracted the shared logic into an `arrowOffset()` helper to eliminate duplication between `Edge.Top` and `Edge.Bottom`.

**`CalloutScreen.kt`** -- Removed two `paddingOffset` parameter usages from demo callouts that no longer need them.

# Show me

Before:

Google Pixel 9 emulator

[callout-bugs-pixel-9.webm](https://github.com/user-attachments/assets/a50ced1d-01cd-4d14-a5cd-5d772d6f9193)

Google Pixel 9 Pro emulator

[callout-bugs-pixel-9-pro.webm](https://github.com/user-attachments/assets/63e4be41-9346-4446-bc70-b7b6bf3cac1d)

After:

Google Pixel 9 emulator

[callout-fix-pixel-9.webm](https://github.com/user-attachments/assets/cf276a80-c4ea-465c-9768-40a26aa434ae)

Google Pixel 9 Pro emulator

[callout-fix-pixel-9-pro.webm](https://github.com/user-attachments/assets/8222e27c-809d-42ed-8b0e-ff92e769592a)