### PR TITLE
WARP-1344: Align Snackbar logic with web and iOS

### DIFF
--- a/warp/src/main/java/com/schibsted/nmp/warp/components/WarpSnackbar.kt
+++ b/warp/src/main/java/com/schibsted/nmp/warp/components/WarpSnackbar.kt
@@ -36,16 +36,17 @@ private const val ACTION_NEW_LINE_THRESHOLD = 10
  * Snackbars provide brief messages about app processes at the bottom of the screen.
  * For more info, look [here](https://warp-ds.github.io/tech-docs/components/snackbar/)
  *
- * The action button is automatically placed on a new line when the action text is at least 10 chars.
- *
  * @param snackbarData Data about the snackbar, including text and action label.
  *   Use WarpSnackbarVisuals to include an icon type, or plain SnackbarVisuals for no icon.
  * @param modifier Modifier for the snackbar.
+ * @param actionPlacement Determines how the action button should be placed.
+ *   Defaults to Auto, which places the action on a new line when the action text is >= 10 characters.
  */
 @Composable
 fun WarpSnackbar(
     snackbarData: SnackbarData,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    actionPlacement: WarpSnackbarActionPlacement = WarpSnackbarActionPlacement.Auto
 ) {
     val warpVisuals = snackbarData.visuals.validate()
 
@@ -54,9 +55,13 @@ fun WarpSnackbar(
     val textContentColor = WarpTheme.colors.text.invertedStatic
     val iconContentColor = WarpTheme.colors.icon.invertedStatic
     val containerColor = WarpTheme.colors.components.tooltip.backgroundStatic
-    val actionOnNewLine = snackbarData.visuals.actionLabel?.let {
-        it.length >= ACTION_NEW_LINE_THRESHOLD
-    } ?: false
+    val computedActionOnNewLine = when (actionPlacement) {
+        WarpSnackbarActionPlacement.Auto -> snackbarData.visuals.actionLabel?.let {
+            it.length >= ACTION_NEW_LINE_THRESHOLD
+        } ?: false
+        WarpSnackbarActionPlacement.Inline -> false
+        WarpSnackbarActionPlacement.NewLine -> true
+    }
 
     Snackbar(
         modifier = modifier.padding(WarpTheme.dimensions.space05),
@@ -87,7 +92,7 @@ fun WarpSnackbar(
                 }
             }
         } else null,
-        actionOnNewLine = actionOnNewLine,
+        actionOnNewLine = computedActionOnNewLine,
         shape = shape,
         containerColor = containerColor,
         contentColor = textContentColor,
@@ -97,7 +102,7 @@ fun WarpSnackbar(
             modifier = Modifier.padding(
                 // Padding is needed, to somewhat adjust offsets caused by component internals.
                 // Noticeable when displaying multiple lines of text.
-                vertical = if (actionOnNewLine) {
+                vertical = if (computedActionOnNewLine) {
                     0.dp
                 } else {
                     WarpTheme.dimensions.space15 / LocalDensity.current.fontScale

--- a/warp/src/main/java/com/schibsted/nmp/warp/components/WarpSnackbarActionPlacement.kt
+++ b/warp/src/main/java/com/schibsted/nmp/warp/components/WarpSnackbarActionPlacement.kt
@@ -1,0 +1,22 @@
+package com.schibsted.nmp.warp.components
+
+/**
+ * Defines how the action button should be placed in a snackbar.
+ */
+sealed interface WarpSnackbarActionPlacement {
+    /**
+     * Automatically determines placement based on action label length.
+     * Action is placed on a new line when the label is 10 or more characters.
+     */
+    data object Auto : WarpSnackbarActionPlacement
+
+    /**
+     * Forces the action button to be placed on the same line as the message.
+     */
+    data object Inline : WarpSnackbarActionPlacement
+
+    /**
+     * Forces the action button to be placed on a new line below the message.
+     */
+    data object NewLine : WarpSnackbarActionPlacement
+}

--- a/warp/src/main/java/com/schibsted/nmp/warp/components/WarpSnackbarVisuals.kt
+++ b/warp/src/main/java/com/schibsted/nmp/warp/components/WarpSnackbarVisuals.kt
@@ -27,8 +27,8 @@ data class WarpSnackbarVisuals(
         require(actionLabel.isNullOrEmpty() || duration != SnackbarDuration.Short) {
             "Snackbars with an action cannot have Short duration. Use Long or Indefinite instead."
         }
-        require(duration == SnackbarDuration.Short || withDismissAction || !actionLabel.isNullOrEmpty()) {
-            "Long and Indefinite snackbars must have either a dismiss action or an action button."
+        require(duration != SnackbarDuration.Indefinite || withDismissAction || !actionLabel.isNullOrEmpty()) {
+            "Indefinite snackbars must have either a dismiss action or an action button."
         }
     }
 }


### PR DESCRIPTION
# Why?

We found a couple of things that behaved differently in the Android Snackbar component.

See [this Slack thread](https://sch-chat.slack.com/archives/C0AR0HNDH5W/p1781513863570729).

# What?

- Allow a long duration, without requiring a dismiss action.
- Allow overriding the auto threshold for action on new line.