### PR TITLE
WARP-1344: Update sample app with action placement capability [TECH]

### DIFF
--- a/app/src/main/java/com/schibsted/nmp/warpapp/ui/SnackbarScreen.kt
+++ b/app/src/main/java/com/schibsted/nmp/warpapp/ui/SnackbarScreen.kt
@@ -264,7 +264,8 @@ fun showWarpSnackbar(
                 type = scenario.type,
                 actionLabel = scenario.actionLabel,
                 withDismissAction = scenario.withDismissAction,
-                duration = scenario.duration
+                duration = scenario.duration,
+                actionPlacement = scenario.placement
             )
         )
     }

--- a/app/src/main/java/com/schibsted/nmp/warpapp/ui/SnackbarScreen.kt
+++ b/app/src/main/java/com/schibsted/nmp/warpapp/ui/SnackbarScreen.kt
@@ -31,6 +31,7 @@ import com.schibsted.nmp.warp.components.WarpButtonStyle
 import com.schibsted.nmp.warp.components.WarpScaffold
 import com.schibsted.nmp.warp.components.WarpSelect
 import com.schibsted.nmp.warp.components.WarpSnackbar
+import com.schibsted.nmp.warp.components.WarpSnackbarActionPlacement
 import com.schibsted.nmp.warp.components.WarpSnackbarType
 import com.schibsted.nmp.warp.components.WarpSnackbarVisuals
 import com.schibsted.nmp.warp.components.WarpSwitch
@@ -66,8 +67,10 @@ fun SnackbarScreenContent() {
     var customDismissable by remember { mutableStateOf(true) }
     var customType by remember { mutableStateOf("Neutral") }
     var customDuration by remember { mutableStateOf(SnackbarDuration.Short.name) }
+    var customPlacement by remember { mutableStateOf("Auto") }
 
     val snackbarTypes = listOf("Neutral", "Positive", "Negative", "Warning", "Info")
+    val placementOptions = listOf("Auto", "Inline", "NewLine")
     val neutralWithIconScenario = WarpSnackbarScenarios.neutralWithIcon()
 
     WarpScaffold(
@@ -189,6 +192,16 @@ fun SnackbarScreenContent() {
 
                     Spacer(modifier = Modifier.height(dimensions.space2))
 
+                    WarpSelect(
+                        value = customPlacement,
+                        onValueChange = { customPlacement = it },
+                        label = "Action Placement",
+                        items = placementOptions,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+
+                    Spacer(modifier = Modifier.height(dimensions.space2))
+
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.SpaceBetween,
@@ -222,13 +235,19 @@ fun SnackbarScreenContent() {
                                     "Info" -> WarpSnackbarType.Info
                                     else -> WarpSnackbarType.Neutral()
                                 }
+                                val placement = when (customPlacement) {
+                                    "Inline" -> WarpSnackbarActionPlacement.Inline
+                                    "NewLine" -> WarpSnackbarActionPlacement.NewLine
+                                    else -> WarpSnackbarActionPlacement.Auto
+                                }
                                 try {
                                     val visuals = WarpSnackbarVisuals(
                                         message = customBodyText,
                                         actionLabel = customActionText.takeIf { it.isNotEmpty() },
                                         withDismissAction = customDismissable,
                                         type = type,
-                                        duration = SnackbarDuration.valueOf(customDuration)
+                                        duration = SnackbarDuration.valueOf(customDuration),
+                                        actionPlacement = placement
                                     )
                                     visuals.validate()
                                     scope.launch {

--- a/warp/src/main/java/com/schibsted/nmp/warp/components/WarpSnackbar.kt
+++ b/warp/src/main/java/com/schibsted/nmp/warp/components/WarpSnackbar.kt
@@ -37,16 +37,13 @@ private const val ACTION_NEW_LINE_THRESHOLD = 10
  * For more info, look [here](https://warp-ds.github.io/tech-docs/components/snackbar/)
  *
  * @param snackbarData Data about the snackbar, including text and action label.
- *   Use WarpSnackbarVisuals to include an icon type, or plain SnackbarVisuals for no icon.
+ *   Use WarpSnackbarVisuals to configure the message, type, actions, and placement.
  * @param modifier Modifier for the snackbar.
- * @param actionPlacement Determines how the action button should be placed.
- *   Defaults to Auto, which places the action on a new line when the action text is >= 10 characters.
  */
 @Composable
 fun WarpSnackbar(
     snackbarData: SnackbarData,
-    modifier: Modifier = Modifier,
-    actionPlacement: WarpSnackbarActionPlacement = WarpSnackbarActionPlacement.Auto
+    modifier: Modifier = Modifier
 ) {
     val warpVisuals = snackbarData.visuals.validate()
 
@@ -55,7 +52,7 @@ fun WarpSnackbar(
     val textContentColor = WarpTheme.colors.text.invertedStatic
     val iconContentColor = WarpTheme.colors.icon.invertedStatic
     val containerColor = WarpTheme.colors.components.tooltip.backgroundStatic
-    val computedActionOnNewLine = when (actionPlacement) {
+    val computedActionOnNewLine = when (warpVisuals.actionPlacement) {
         WarpSnackbarActionPlacement.Auto -> snackbarData.visuals.actionLabel?.let {
             it.length >= ACTION_NEW_LINE_THRESHOLD
         } ?: false

--- a/warp/src/main/java/com/schibsted/nmp/warp/components/WarpSnackbarVisuals.kt
+++ b/warp/src/main/java/com/schibsted/nmp/warp/components/WarpSnackbarVisuals.kt
@@ -19,6 +19,7 @@ data class WarpSnackbarVisuals(
         SnackbarDuration.Long
     },
     val type: WarpSnackbarType = WarpSnackbarType.Neutral(),
+    val actionPlacement: WarpSnackbarActionPlacement = WarpSnackbarActionPlacement.Auto,
 ) : SnackbarVisuals {
     init {
         require(message.isNotBlank()) {

--- a/warp/src/main/java/com/schibsted/nmp/warp/utils/WarpSnackbarScenarios.kt
+++ b/warp/src/main/java/com/schibsted/nmp/warp/utils/WarpSnackbarScenarios.kt
@@ -2,6 +2,7 @@ package com.schibsted.nmp.warp.utils
 
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.runtime.Composable
+import com.schibsted.nmp.warp.components.WarpSnackbarActionPlacement
 import com.schibsted.nmp.warp.components.WarpSnackbarType
 import com.schibsted.nmp.warp.theme.WarpIconResources
 
@@ -15,7 +16,8 @@ data class WarpSnackbarScenario(
     val type: WarpSnackbarType,
     val actionLabel: String? = null,
     val withDismissAction: Boolean = true,
-    val duration: SnackbarDuration = SnackbarDuration.Short
+    val duration: SnackbarDuration = SnackbarDuration.Short,
+    val placement: WarpSnackbarActionPlacement = WarpSnackbarActionPlacement.Auto
 )
 
 object WarpSnackbarScenarios {
@@ -60,7 +62,9 @@ object WarpSnackbarScenarios {
         message = "This should have long duration",
         type = WarpSnackbarType.Info,
         actionLabel = "View",
-        duration = SnackbarDuration.Long
+        duration = SnackbarDuration.Long,
+        placement = WarpSnackbarActionPlacement.NewLine
+
     )
 
     val infoIndefinite = WarpSnackbarScenario(

--- a/warp/src/main/java/com/schibsted/nmp/warp/utils/WarpSnackbarScenarios.kt
+++ b/warp/src/main/java/com/schibsted/nmp/warp/utils/WarpSnackbarScenarios.kt
@@ -63,7 +63,6 @@ object WarpSnackbarScenarios {
         type = WarpSnackbarType.Info,
         actionLabel = "View",
         duration = SnackbarDuration.Long,
-        placement = WarpSnackbarActionPlacement.NewLine
 
     )
 

--- a/warp/src/main/java/com/schibsted/nmp/warp/utils/WarpSnackbarScenarios.kt
+++ b/warp/src/main/java/com/schibsted/nmp/warp/utils/WarpSnackbarScenarios.kt
@@ -63,7 +63,6 @@ object WarpSnackbarScenarios {
         type = WarpSnackbarType.Info,
         actionLabel = "View",
         duration = SnackbarDuration.Long,
-
     )
 
     val infoIndefinite = WarpSnackbarScenario(


### PR DESCRIPTION
# Why?

It makes more sense to optionally control the button placement via visuals, rather than as a top level param.

# What?

Things are pretty much the same, I've just moved the param one level further down. It is kind of a breaking change, but given the early days of the component and the fact that it has a default value, I think it's fine.

I'm not 100% sure on how to deal with this when it comes to docs, but I can keep some changes stashed for now.
