### PR TITLE
NOJIRA: Fix horizontal preview device spec

### DIFF
--- a/app/src/main/java/com/schibsted/nmp/warpapp/ui/NavigationBarScreen.kt
+++ b/app/src/main/java/com/schibsted/nmp/warpapp/ui/NavigationBarScreen.kt
@@ -89,7 +89,7 @@ internal fun NavigationBarContentPreview(
     }
 }
 
-@Preview(name = "WarpNavigationBar — horizontal", widthDp = 640, showBackground = true)
+@Preview(name = "WarpNavigationBar — horizontal", showBackground = true, device = "spec:parent=pixel_5,orientation=landscape")
 @Composable
 internal fun WarpNavBarHorizontalPreview(
     @PreviewParameter(FlavorPreviewProvider::class) flavor: String,

--- a/warp/src/main/java/com/schibsted/nmp/warp/components/WarpNavigationBar.kt
+++ b/warp/src/main/java/com/schibsted/nmp/warp/components/WarpNavigationBar.kt
@@ -166,7 +166,7 @@ fun WarpNavigationBarPreview() {
     )
 }
 
-@Preview(name = "WarpNavigationBar — horizontal", widthDp = 640, showBackground = true)
+@Preview(name = "WarpNavigationBar — horizontal", showBackground = true, device = "spec:parent=pixel_5,orientation=landscape")
 @Composable
 fun WarpNavigationBarHorizontalPreview() {
     WarpNavigationBar(


### PR DESCRIPTION
Use a proper landscape device spec instead of `widthDp = 640` for horizontal navigation bar previews, as suggested by Balder.

**Changes:**
- `WarpNavigationBar.kt`: `@Preview` annotation updated to `device = "spec:parent=pixel_5,orientation=landscape"`
- `NavigationBarScreen.kt`: same fix applied to the screen-level horizontal preview