### PR TITLE
NOJIRA: Deprecated WarpToast

### DIFF
--- a/warp/src/main/java/com/schibsted/nmp/warp/components/WarpToast.kt
+++ b/warp/src/main/java/com/schibsted/nmp/warp/components/WarpToast.kt
@@ -42,6 +42,10 @@ import kotlin.concurrent.schedule
  * @param onDismiss Callback to be invoked when the toast is dismissed.
  */
 @Composable
+@Deprecated(
+    message = "Use WarpSnackbar instead.",
+    level = DeprecationLevel.WARNING
+)
 fun WarpToast(
     modifier: Modifier = Modifier,
     state: WarpToastState,


### PR DESCRIPTION
# Why?

We have announced on Slack that it is deprecated, so we should reflect this in the code as well.

# What?

Added deprecation notice on the component itself, suggesting to use what we consider its replacement instead.

# Note

I considered if some other classes, like `WarpToastType` should be deprecated as well, but decided that as long as the component has the annotation, everything else is implied.