### PR TITLE
WARP-1359: fix WarpNavigationBar — Box wrapper absorbs caller modifiers

### DIFF
--- a/buildSrc/src/main/java/ConfigData.kt
+++ b/buildSrc/src/main/java/ConfigData.kt
@@ -1,8 +1,8 @@
 object ConfigData {
     const val compileSdkVersion = 35
     const val minSdkVersion = 24
-    const val warpVersion = "0.0.61"
-    const val sampleAppVersionCode = 61
+    const val warpVersion = "0.0.62"
+    const val sampleAppVersionCode = 62
     const val groupId = "com.schibsted.nmp.warp"
     const val artifactIdWarp = "warp-android"
     const val artifactIdFinn = "warp-android-finn"

--- a/warp/src/main/java/com/schibsted/nmp/warp/components/WarpNavigationBar.kt
+++ b/warp/src/main/java/com/schibsted/nmp/warp/components/WarpNavigationBar.kt
@@ -1,6 +1,7 @@
 package com.schibsted.nmp.warp.components
 
 import android.content.res.Configuration
+import androidx.compose.foundation.layout.Box
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.NavigationItemColors
@@ -84,19 +85,20 @@ fun WarpNavigationBar(
         disabledTextColor = warpColors.icon.default,
     )
 
-    ShortNavigationBar(
-        modifier = modifier,
-        containerColor = warpColors.background.default,
-        arrangement = if (showHorizontal) ShortNavigationBarArrangement.Centered else ShortNavigationBarArrangement.EqualWeight
-    ) {
-        items.forEachIndexed { index, item ->
-            WarpNavigationBarItem(
-                item = item,
-                isSelected = index == selectedIndex,
-                onClick = { onItemSelected(index) },
-                iconPosition = iconPosition,
-                itemColors = itemColors,
-            )
+    Box(modifier = modifier) {
+        ShortNavigationBar(
+            containerColor = warpColors.background.default,
+            arrangement = if (showHorizontal) ShortNavigationBarArrangement.Centered else ShortNavigationBarArrangement.EqualWeight,
+        ) {
+            items.forEachIndexed { index, item ->
+                WarpNavigationBarItem(
+                    item = item,
+                    isSelected = index == selectedIndex,
+                    onClick = { onItemSelected(index) },
+                    iconPosition = iconPosition,
+                    itemColors = itemColors,
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Problem

`WarpNavigationBar` passes the caller's `modifier` directly to `ShortNavigationBar`. When that modifier contains a size constraint (e.g. `fillMaxWidth()`), `ShortNavigationBar`'s `EqualWeightContentMeasurePolicy` receives `hasBoundedWidth=false` and renders only 1 item instead of all items.

This affects both `EqualWeight` (portrait) and `Centered` (landscape) arrangements.

## Fix

Wrap `ShortNavigationBar` in a `Box(modifier = modifier)`. The `Box` absorbs all caller modifiers. `ShortNavigationBar` itself gets no modifier, so it always measures with unbounded width and the measure policy works correctly.
