### PR TITLE
WARP-1377: add modifier param to WarpNavItem for per-item decoration

### DIFF
--- a/buildSrc/src/main/java/ConfigData.kt
+++ b/buildSrc/src/main/java/ConfigData.kt
@@ -1,8 +1,8 @@
 object ConfigData {
     const val compileSdkVersion = 35
     const val minSdkVersion = 24
-    const val warpVersion = "0.0.62"
-    const val sampleAppVersionCode = 62
+    const val warpVersion = "0.0.63"
+    const val sampleAppVersionCode = 63
     const val groupId = "com.schibsted.nmp.warp"
     const val artifactIdWarp = "warp-android"
     const val artifactIdFinn = "warp-android-finn"

--- a/warp/src/main/java/com/schibsted/nmp/warp/components/WarpNavigationBar.kt
+++ b/warp/src/main/java/com/schibsted/nmp/warp/components/WarpNavigationBar.kt
@@ -32,12 +32,15 @@ enum class WarpNavBarLayout { Auto, Vertical, Horizontal }
  *   For avatar images that don't tint, ignore the color parameter.
  * @param badgeCount Number to display in the badge. 0 means no badge. Must be >= 0.
  * @param showDot True to show a dot badge (no number). Ignored if [badgeCount] > 0.
+ * @param modifier Modifier applied to this item's [ShortNavigationBarItem]. Use to add semantics,
+ *   test tags, or other per-item decoration. Defaults to [Modifier].
  */
 data class WarpNavItem(
     val label: String,
     val icon: @Composable (color: Color, isSelected: Boolean) -> Unit,
     val badgeCount: Int = 0,
     val showDot: Boolean = false,
+    val modifier: Modifier = Modifier,
 ) {
     init {
         require(badgeCount >= 0) { "badgeCount must be >= 0, was $badgeCount" }
@@ -92,6 +95,7 @@ fun WarpNavigationBar(
         ) {
             items.forEachIndexed { index, item ->
                 WarpNavigationBarItem(
+                    modifier = item.modifier,
                     item = item,
                     isSelected = index == selectedIndex,
                     onClick = { onItemSelected(index) },


### PR DESCRIPTION
## Summary

- Adds `modifier: Modifier = Modifier` field to `WarpNavItem` data class
- `WarpNavigationBar` now passes `item.modifier` through to `WarpNavigationBarItem`
- KDoc updated with `@param modifier` description

Default is `Modifier` so all existing callers are unaffected.

