### PR TITLE
NOJIRA: Provide MaterialTheme in FinnWarpTheme

### DIFF
--- a/buildSrc/src/main/java/ConfigData.kt
+++ b/buildSrc/src/main/java/ConfigData.kt
@@ -1,8 +1,8 @@
 object ConfigData {
     const val compileSdkVersion = 35
     const val minSdkVersion = 24
-    const val warpVersion = "0.0.63"
-    const val sampleAppVersionCode = 63
+    const val warpVersion = "0.0.64"
+    const val sampleAppVersionCode = 64
     const val groupId = "com.schibsted.nmp.warp"
     const val artifactIdWarp = "warp-android"
     const val artifactIdFinn = "warp-android-finn"

--- a/warp-finn/src/main/java/com/schibsted/nmp/warp/brands/finn/FinnWarpTheme.kt
+++ b/warp-finn/src/main/java/com/schibsted/nmp/warp/brands/finn/FinnWarpTheme.kt
@@ -3,7 +3,10 @@ package com.schibsted.nmp.warp.brands.finn
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.ripple.RippleAlpha
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RippleConfiguration
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import com.schibsted.nmp.warp.theme.WarpDimensions
 import com.schibsted.nmp.warp.theme.WarpResources
@@ -15,8 +18,8 @@ fun FinnWarpTheme(
     content: @Composable () -> Unit,
     forceDarkMode: Boolean? = null
 ) {
-    val finnColors = forceDarkMode?.let { if (it) FinnDarkColors else FinnColors }
-        ?: if (isSystemInDarkTheme()) FinnDarkColors else FinnColors
+    val isDark = forceDarkMode ?: isSystemInDarkTheme()
+    val finnColors = if (isDark) FinnDarkColors else FinnColors
     val finnDimensions = WarpDimensions
     val finnResources = WarpResources
     val finnRippleConfig = RippleConfiguration(
@@ -24,14 +27,16 @@ fun FinnWarpTheme(
         rippleAlpha = RippleAlpha(0f, 0.5f, 0f, 0.5f)
     )
 
-    WarpTheme(
-        colors = finnColors,
-        typography = FinnTypography,
-        shapes = FinnShapes(finnDimensions),
-        resources = finnResources,
-        strings = FinnBrandStrings,
-        content = content,
-        rippleConfig = finnRippleConfig,
-        dimensions = finnDimensions
-    )
+    MaterialTheme(colorScheme = if (isDark) darkColorScheme() else lightColorScheme()) {
+        WarpTheme(
+            colors = finnColors,
+            typography = FinnTypography,
+            shapes = FinnShapes(finnDimensions),
+            resources = finnResources,
+            strings = FinnBrandStrings,
+            content = content,
+            rippleConfig = finnRippleConfig,
+            dimensions = finnDimensions
+        )
+    }
 }


### PR DESCRIPTION
## Why

Downstream Compose screens can combine Warp components with Material 3 primitives such as scaffolds, top-app-bar behavior, pull-to-refresh, swipe-to-dismiss, and snackbars. `FinnWarpTheme` currently provides Warp tokens but no Material 3 theme for those primitives.

## What

- Wrap the existing `WarpTheme` in a Material 3 `MaterialTheme`
- Select the Material 3 light or dark scheme from the same resolved dark-mode state as the FINN theme
- Keep existing Warp colors, typography, shapes, resources, strings, dimensions, and ripple configuration unchanged
- Bump the Warp library version from `0.0.63` to `0.0.64` and the sample app version code from `63` to `64`

## Testing

- `gradlew :warp-finn:testDebugUnitTest :warp-finn:lintDebug :warp-finn:assembleDebug`
- `gradlew :warp-finn:assembleDebug` after the version bump
- `:snapshot:snapshot-snackbar:verifyPaparazziDebug` was also attempted; Paparazzi fails to initialize its bridge identically on this branch and clean `origin/develop` (all brands), so it is unrelated to this change.